### PR TITLE
Changes required to enable RBAC Integrated with Github

### DIFF
--- a/installer/charts/rhtap-dh/templates/app-config-content.yaml
+++ b/installer/charts/rhtap-dh/templates/app-config-content.yaml
@@ -87,6 +87,17 @@ backend:
   cors:
     origin: ${BACKEND_URL}
 catalog:
+  {{- if and .Values.developerHub.enableRBAC $githubSecretObj }}
+  providers:
+    githubOrg:
+      id: production
+      githubUrl: ${GITHUB__URL}
+      orgs: ['${GITHUB__ORG}']
+      schedule:
+        initialDelay: { seconds: 30 }
+        frequency: { minutes: 15 }
+        timeout: { minutes: 5 }
+  {{- end }}
   locations:
     - target: ${DEVELOPER_HUB__CATALOG__URL}
       type: url
@@ -95,6 +106,7 @@ catalog:
       - Component
       - System
       - Group
+      - User
       - Resource
       - Location
       - Template
@@ -151,9 +163,19 @@ jenkins:
 nexus:
   uiUrl: ${NEXUS__URL}
 {{- end }}
+{{- if .Values.developerHub.enableRBAC }}
 permission:
-  # Disable RBACs
+  enabled: true
+  {{- if $githubSecretObj }}
+  rbac:
+    admin:
+      users:
+      - name: user:default/${GITHUB__USERNAME}
+  {{- end}}
+{{- else }}
+permission:
   enabled: false
+{{- end }}
 proxy:
   endpoints:
   {{- if $artifactorySecretObj }}

--- a/installer/charts/rhtap-dh/templates/extra-env.yaml
+++ b/installer/charts/rhtap-dh/templates/extra-env.yaml
@@ -66,6 +66,8 @@ data:
     GITHUB__HOST: {{ $ghSecretData.host }}
     GITHUB__TOKEN: {{ $ghSecretData.token }}
     GITHUB__URL: {{ print "https://" ($ghSecretData.host | b64dec) | b64enc }}
+    GITHUB__USERNAME: {{ $ghSecretData.username }}
+    GITHUB__ORG: {{ $ghSecretData.ownerLogin }}
     {{- end }}
 {{- end }}
 {{- $glSecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-gitlab-integration") -}}

--- a/installer/charts/rhtap-dh/templates/plugins-content.yaml
+++ b/installer/charts/rhtap-dh/templates/plugins-content.yaml
@@ -146,4 +146,19 @@ plugins:
     package: ./dynamic-plugins/dist/backstage-plugin-techdocs
   - disabled: false
     package: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
+
+  #
+  # RBAC
+  #
+  {{- $githubSecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-github-integration") }}
+  {{- if and .Values.developerHub.enableRBAC $githubSecretObj }}
+  - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
+    disabled: false
+  - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-org-dynamic
+    disabled: false
+    pluginConfig:
+      catalog:
+        githubOrg:
+          githubUrl: ${GITHUB__URL}
+  {{- end}}
 {{- end }}

--- a/installer/charts/values.yaml.tpl
+++ b/installer/charts/values.yaml.tpl
@@ -294,6 +294,7 @@ integrations:
 
 developerHub:
   namespace: {{ $rhdh.Namespace }}
+  enableRBAC: {{ $rhdh.Properties.enableRBAC }}
   ingressDomain: {{ $ingressDomain }}
   catalogURL: {{ $catalogURL }}
   integrationSecrets:

--- a/installer/config.yaml
+++ b/installer/config.yaml
@@ -25,6 +25,7 @@ rhtapCLI:
       properties:
         catalogURL: https://github.com/redhat-appstudio/tssc-sample-templates/blob/main/all.yaml
         manageSubscription: true
+        enableRBAC: false
         # namespacePrefixes:
         #   - rhtap-app
     redHatAdvancedClusterSecurity:


### PR DESCRIPTION
Two plugins are required for a better user experience integrating RBAC with Github users and groups. 